### PR TITLE
Add EXCLUSIVE_LOCKS_REQUIRED for auxpow miner

### DIFF
--- a/src/rpc/auxpow_miner.h
+++ b/src/rpc/auxpow_miner.h
@@ -61,13 +61,15 @@ private:
    * fills in the difficulty target value.
    */
   const CBlock* getCurrentBlock (const CTxMemPool& mempool,
-                                 const CScript& scriptPubKey, uint256& target);
+                                 const CScript& scriptPubKey, uint256& target)
+      EXCLUSIVE_LOCKS_REQUIRED (cs);
 
   /**
    * Looks up a previously constructed block by its (hex-encoded) hash.  If the
    * block is found, it is returned.  Otherwise, a JSONRPCError is thrown.
    */
-  const CBlock* lookupSavedBlock (const std::string& hashHex) const;
+  const CBlock* lookupSavedBlock (const std::string& hashHex) const
+      EXCLUSIVE_LOCKS_REQUIRED (cs);
 
   friend class auxpow_tests::AuxpowMinerForTest;
 


### PR DESCRIPTION
Define some functions in auxpow miner as `EXCLUSIVE_LOCKS_REQUIRED(cs)`, when they call `AssertLockHeld`.  This otherwise fails static analysis of clang.

Fixes #388.